### PR TITLE
Improve SELinux policy workaround on device/phh/treble conflict to exit with SEPOL_OK instead of SEPOL_EEXIST

### DIFF
--- a/libsepol/cil/src/cil_build_ast.c
+++ b/libsepol/cil/src/cil_build_ast.c
@@ -141,7 +141,6 @@ int cil_add_decl_to_symtab(struct cil_db *db, symtab_t *symtab, hashtab_key_t ke
 		/* multiple_decls is enabled and works for this datum type, add node */
 		cil_list_append(prev->nodes, CIL_NODE, node);
 		node->data = prev;
-		return SEPOL_EEXIST;
 	}
 
 	return SEPOL_OK;


### PR DESCRIPTION
This fixes boot on many Samsung devices as exiting with SEPOL_EEXIST will prevent them to boot